### PR TITLE
Fix bug induced by my (foolish) attempt to overload methods in JavaScript. Not a thing, apparently.

### DIFF
--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -348,21 +348,5 @@
 
 </section>
 </body>
-<script>
-   $('#TheirBoard td').click(function(event) {
-   console.log("CLICK EVENT");
 
-   $.ajax("/fire", {
-      success: function(data) {
-         <!--$('#main').html($(data).find('#main *'));-->
-         <!--$('#notification-bar').text('The page has been successfully loaded');-->
-         console.log("FIRE SUCCESS");
-      },
-      error: function() {
-         <!--$('#notification-bar').text('An error occurred');-->
-         console.log("FIRE FAIL");
-      }
-   });
-});
-</script>
 </html>

--- a/src/main/resources/public/js/app.js
+++ b/src/main/resources/public/js/app.js
@@ -38,28 +38,13 @@ function placeShip() {
 }
 
 //Similar to placeShip, but instead it will fire at a location the user selects.
-function fire(){
-   var request = $.ajax({
-     url: "/fire/"+$( "#colFire" ).val()+"/"+$( "#rowFire" ).val(),
-     method: "post",
-     data: JSON.stringify(gameModel),
-     contentType: "application/json; charset=utf-8",
-     dataType: "json"
-   });
-
-   request.done(function( currModel ) {
-     displayGameState(currModel);
-     gameModel = currModel;
-
-   });
-
-   request.fail(function( jqXHR, textStatus ) {
-     alert( "Request failed: " + textStatus );
-   });
-
-}
-
-function fire(row, column){
+function fire(row, column) {
+    if (!row) {
+        row = $( "#colFire" ).val();
+    }
+    if (!column) {
+        column = $( "#rowFire" ).val();
+    }
     var request = $.ajax({
         url: "/fire/"+column+"/"+row,
         method: "post",

--- a/src/main/resources/public/js/app.js
+++ b/src/main/resources/public/js/app.js
@@ -7,6 +7,11 @@ $( document ).ready(function() {
     displayGameState(json);
     gameModel = json;
    });
+
+    $( '#TheirBoard' ).on("click", "td", function (event) {
+        var coords = this.id.split("_");
+        fire(coords[0], coords[1]);
+    });
 });
 
 function placeShip() {
@@ -51,6 +56,27 @@ function fire(){
    request.fail(function( jqXHR, textStatus ) {
      alert( "Request failed: " + textStatus );
    });
+
+}
+
+function fire(row, column){
+    var request = $.ajax({
+        url: "/fire/"+column+"/"+row,
+        method: "post",
+        data: JSON.stringify(gameModel),
+        contentType: "application/json; charset=utf-8",
+        dataType: "json"
+    });
+
+    request.done(function( currModel ) {
+        displayGameState(currModel);
+        gameModel = currModel;
+
+    });
+
+    request.fail(function( jqXHR, textStatus ) {
+        alert( "Request failed: " + textStatus );
+    });
 
 }
 


### PR DESCRIPTION
Instead of having both `fire()` and `fire(row, column)` (so that the firing form would still work), I'm just keeping the latter and having the arguments default to what's in the form if they're undefined.

The firing form might get removed eventually, but this is so that stuff works in the meantime. Sorry about the line changes that are just spaces.